### PR TITLE
Remove Inform7's command "read" as being interpreted as "examine"

### DIFF
--- a/story.ni
+++ b/story.ni
@@ -2441,6 +2441,7 @@ The match-count is a number that varies. The match-count is 6.
 Instead of examining the matchbook when the match-lit is true:
 	say "The match is burning."
 
+Understand the command "read" as something new.
 Reading is an action applying to one thing. Understand "read [something]" as reading.
 
 Instead of reading the matchbook:


### PR DESCRIPTION
## Summary

In Inform7, `read` is considered a synonym of `examine`. This means `read door` when in `west-of-house` will produce the description (that the door is boarded shut) rather than using the "instead of reading the door..." rule.

I tested this with Borogove manually. 

I'm not completely sure how this template works, so let me know if I've removed the wrong options.

## Version Impact

- [x] Change applies to current version only
- [x] Change propagated to all later versions

## Documentation Checklist
- [x] No documentation updates needed

## Testing Checklist

- [x] Manually tested specific game commands
